### PR TITLE
Disable the new xbindkeysrc by default

### DIFF
--- a/tablet/tablet-mode.sh
+++ b/tablet/tablet-mode.sh
@@ -21,4 +21,4 @@ setkeycodes e058 85 # Tablet mode
 setkeycodes e059 89 # Laptop mode
 
 # Start xbindkeys with configuration file
-su $user -c "xbindkeys -f $config -n"
+# su $user -c "xbindkeys -f $config -n"


### PR DESCRIPTION
The functionality of disabling the touchpad, trackpoint and keyboard in tablet mode is already a feature of the BIOS on this device.
The BIOS-functionality is superior in that case, because it is faster and more reliable.
Using the functionality of this script additionally to the BIOS functionality will result in problems like disabled mouse input if you go into hibernation in tablet mode and continue in laptop mode.

The keycodes are still useful, for example for starting touchpad controls at the user level.